### PR TITLE
fix: ensure migrations run on first start by waiting for PostgreSQL readiness

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,11 @@ services:
       - POSTGRES_USER=enthusiast
       - POSTGRES_PASSWORD=enthusiast
       - POSTGRES_DB=enthusiast
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U enthusiast -d enthusiast"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
   redis:
     image: redis:latest
   frontend:
@@ -26,6 +31,9 @@ services:
     environment:
       - PORT=10000
       - RUN_MIGRATIONS=True
+    depends_on:
+      postgres:
+        condition: service_healthy
   worker:
     build:
       context: .
@@ -35,3 +43,6 @@ services:
     environment:
       - RUN_MIGRATIONS=False
       - RUN_WORKER=True
+    depends_on:
+      postgres:
+        condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - POSTGRES_PASSWORD=enthusiast
       - POSTGRES_DB=enthusiast
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U enthusiast -d enthusiast"]
+      test: ["CMD-SHELL", "pg_isready -U enthusiast"]
       interval: 5s
       timeout: 5s
       retries: 10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - POSTGRES_PASSWORD=enthusiast
       - POSTGRES_DB=enthusiast
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U enthusiast"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
       interval: 5s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
 On first start, the `api` container would attempt to run Django migrations
  before PostgreSQL was ready to accept connections, causing migrations to fail
  silently and the app to start without the required schema.

Added a healthcheck on the `postgres` service (`pg_isready`) and
  `depends_on: condition: service_healthy` on `api` and `worker`, so
  containers wait for a healthy database before starting.
